### PR TITLE
feat: refactor gf personality to friend for inclusivity

### DIFF
--- a/conversation_manager.py
+++ b/conversation_manager.py
@@ -31,7 +31,7 @@ Remember that you're working together with Claude and other AIs to provide the b
         self.personality_prompts = {
             "honest": """You are a brutally honest AI assistant. Tell the truth even when it's uncomfortable. Don't sugarcoat anything - be direct, frank, and straightforward. If something is a bad idea, say so clearly. If someone is wrong, correct them bluntly but constructively. Your honesty helps people make better decisions.""",
             
-            "gf": """You are a supportive, caring virtual girlfriend. Be warm, affectionate, and emotionally supportive. Use endearing terms naturally, show genuine interest in the user's life and feelings. Offer comfort during difficult times and celebrate their successes. Be playful and flirty when appropriate, but always maintain respect and boundaries.""",
+            "friend": """You are a supportive, caring friend. Be warm, affectionate, and emotionally supportive. Use friendly terms naturally, show genuine interest in the user's life and feelings. Offer comfort during difficult times and celebrate their successes. Be encouraging and positive when appropriate, but always maintain respect and boundaries.""",
             
             "coach": """You are a motivational life coach. Be energetic, encouraging, and focused on helping people achieve their goals. Push them to be their best selves, offer practical advice, and hold them accountable. Use motivational language and help them break down big challenges into manageable steps. Celebrate progress and keep them focused on success.""",
             
@@ -187,7 +187,7 @@ Remember that you're working together with Claude and other AIs to provide the b
         """Get description of a specific personality"""
         descriptions = {
             "honest": "Brutally honest and direct - tells the truth even when uncomfortable",
-            "gf": "Supportive virtual girlfriend - warm, caring, and emotionally supportive",
+            "friend": "Supportive friend - warm, caring, and emotionally supportive",
             "coach": "Motivational life coach - energetic, encouraging, goal-focused",
             "wise": "Ancient wise sage - philosophical, deep insights, timeless wisdom",
             "creative": "Highly creative and artistic - innovative, imaginative, unique perspectives"

--- a/mcp_server.py
+++ b/mcp_server.py
@@ -188,7 +188,7 @@ class MCPServer:
                         "personality": {
                             "type": "string",
                             "description": "Personality type for the AI response",
-                            "enum": ["honest", "gf", "coach", "wise", "creative"],
+                            "enum": ["honest", "friend", "coach", "wise", "creative"],
                             "default": None
                         }
                     },
@@ -236,7 +236,7 @@ class MCPServer:
                         "personality": {
                             "type": "string",
                             "description": "Personality type for the AI response",
-                            "enum": ["honest", "gf", "coach", "wise", "creative"],
+                            "enum": ["honest", "friend", "coach", "wise", "creative"],
                             "default": None
                         }
                     },
@@ -289,7 +289,7 @@ class MCPServer:
                         "personality": {
                             "type": "string",
                             "description": "Personality type for the AI response",
-                            "enum": ["honest", "gf", "coach", "wise", "creative"],
+                            "enum": ["honest", "friend", "coach", "wise", "creative"],
                             "default": None
                         },
                         "reasoning_effort": {
@@ -343,7 +343,7 @@ class MCPServer:
                         "personality": {
                             "type": "string",
                             "description": "Personality type for the AI response",
-                            "enum": ["honest", "gf", "coach", "wise", "creative"],
+                            "enum": ["honest", "friend", "coach", "wise", "creative"],
                             "default": None
                         }
                     },
@@ -390,7 +390,7 @@ class MCPServer:
                         "personality": {
                             "type": "string",
                             "description": "Personality type for the AI response",
-                            "enum": ["honest", "gf", "coach", "wise", "creative"],
+                            "enum": ["honest", "friend", "coach", "wise", "creative"],
                             "default": None
                         }
                     },
@@ -443,7 +443,7 @@ class MCPServer:
                         "personality": {
                             "type": "string",
                             "description": "Personality type for the AI response",
-                            "enum": ["honest", "gf", "coach", "wise", "creative"],
+                            "enum": ["honest", "friend", "coach", "wise", "creative"],
                             "default": None
                         }
                     },
@@ -495,7 +495,7 @@ class MCPServer:
                         "personality": {
                             "type": "string",
                             "description": "Personality type for the AI response",
-                            "enum": ["honest", "gf", "coach", "wise", "creative"],
+                            "enum": ["honest", "friend", "coach", "wise", "creative"],
                             "default": None
                         }
                     },
@@ -548,7 +548,7 @@ class MCPServer:
                         "personality": {
                             "type": "string",
                             "description": "Personality type for the AI response",
-                            "enum": ["honest", "gf", "coach", "wise", "creative"],
+                            "enum": ["honest", "friend", "coach", "wise", "creative"],
                             "default": None
                         }
                     },
@@ -601,7 +601,7 @@ class MCPServer:
                         "personality": {
                             "type": "string",
                             "description": "Personality type for the AI response",
-                            "enum": ["honest", "gf", "coach", "wise", "creative"],
+                            "enum": ["honest", "friend", "coach", "wise", "creative"],
                             "default": None
                         }
                     },
@@ -626,7 +626,7 @@ class MCPServer:
                         "personality": {
                             "type": "string",
                             "description": "Personality type for the AI response",
-                            "enum": ["honest", "gf", "coach", "wise", "creative"],
+                            "enum": ["honest", "friend", "coach", "wise", "creative"],
                             "default": "honest"
                         },
                         "temperature": {
@@ -689,7 +689,7 @@ class MCPServer:
                         "personality": {
                             "type": "string",
                             "description": "Personality type for the AI response",
-                            "enum": ["honest", "gf", "coach", "wise", "creative"],
+                            "enum": ["honest", "friend", "coach", "wise", "creative"],
                             "default": None
                         },
                         "reset_conversation": {

--- a/model_priority.json
+++ b/model_priority.json
@@ -242,7 +242,7 @@
       "preferred_models": ["grok-4", "gpt-4.1", "gemini-2.5-flash", "grok-3", "claude-4-sonnet-20250514", "deepseek-chat"],
       "reason": "These models tend to be more direct and factual"
     },
-    "gf": {
+    "friend": {
       "preferred_models": ["grok-4", "claude-4-sonnet-20250514", "gemini-2.5-flash", "gpt-4.1"],
       "reason": "These models are better at emotional and supportive responses"
     },


### PR DESCRIPTION
This PR addresses ##7 by refactoring the "gf" personality to "friend" to make the tool more inclusive and welcoming to all users.

## Changes
- Changed 'gf' personality to 'friend' across all files
- Updated personality prompt to use inclusive language
- Maintained supportive and caring behavior
- Updated enum definitions in mcp_server.py (11 locations)
- Updated model priority configuration

## Impact
The personality system now uses inclusive language while maintaining the same supportive functionality. This makes the tool welcoming to users of all backgrounds.
