### PR TITLE
Support GPT 5 series, and add :think for thinking

### DIFF
--- a/ai_providers.py
+++ b/ai_providers.py
@@ -129,6 +129,11 @@ class AIProviders:
                 token_param: max_tokens
             }
             
+            # Handle "thinking" models
+            if ":think" in model:
+                kwargs["model"] = model.replace(":think", "")
+                kwargs["reasoning_effort"] = "high"
+
             response = self.clients.openai_client.chat.completions.create(**kwargs)
             response_content = response.choices[0].message.content
             

--- a/mcp_server.py
+++ b/mcp_server.py
@@ -160,8 +160,8 @@ class MCPServer:
                         "model": {
                             "type": "string",
                             "description": "OpenAI model to use",
-                            "enum": ["o4-mini", "gpt-4.1", "gpt-4o", "gpt-4o-mini"],
-                            "default": "gpt-4.1"
+                            "enum": ["gpt-5:think", "gpt-5", "gpt-5-mini:think", "gpt-5-mini", "gpt-5-nano:think", "gpt-5-nano", "o4-mini", "gpt-4.1", "gpt-4o", "gpt-4o-mini"],
+                            "default": "gpt-5"
                         },
                         "temperature": {
                             "type": "number",

--- a/model_priority.json
+++ b/model_priority.json
@@ -20,6 +20,42 @@
     },
     {
       "platform": "openai",
+      "model": "gpt-5:think",
+      "description": "OpenAI's most powerful model with enhanced reasoning",
+      "quality_score": 99
+    },
+    {
+      "platform": "openai",
+      "model": "gpt-5",
+      "description": "OpenAI's most powerful model for complex tasks",
+      "quality_score": 98
+    },
+    {
+      "platform": "openai",
+      "model": "gpt-5-mini:think",
+      "description": "OpenAI's fast model with enhanced reasoning",
+      "quality_score": 91
+    },
+    {
+      "platform": "openai",
+      "model": "gpt-5-mini",
+      "description": "OpenAI's fast and cost-effective model",
+      "quality_score": 90
+    },
+    {
+      "platform": "openai",
+      "model": "gpt-5-nano:think",
+      "description": "OpenAI's quickest model with enhanced reasoning",
+      "quality_score": 86
+    },
+    {
+      "platform": "openai",
+      "model": "gpt-5-nano",
+      "description": "OpenAI's quickest model for high-throughput tasks",
+      "quality_score": 85
+    },
+    {
+      "platform": "openai",
       "model": "gpt-4.1",
       "description": "OpenAI's latest flagship model - top tier reasoning and knowledge",
       "quality_score": 94


### PR DESCRIPTION
- Added the new models to `model_priority.json` with appropriate quality scores.
- Added `:think` variants for these models, which use the `reasoning_effort` parameter in the OpenAI API.
- Updated `mcp_server.py` to ensure the new models are properly recognized.
- Updated `ai_providers.py` to handle the new `:think` variants by setting `reasoning_effort` to `high`.