### PR TITLE
Fix Anthropic Claude model IDs (Claude 4/4.5 + 3.7)

### DIFF
--- a/README.md
+++ b/README.md
@@ -378,9 +378,11 @@ You should see `second-opinion` in the list of available MCP servers.
 
 | Model | Description | Best For |
 |-------|-------------|----------|
-| `claude-4-opus-20250522` | Most advanced Claude | 🧠 Complex reasoning |
-| `claude-4-sonnet-20250522` | Versatile general tasks | ⚖️ Balanced performance |
-| `claude-3-7-sonnet-20250224` | Stable and reliable | 🛡️ Production use |
+| `claude-opus-4-20250514` | Most advanced Claude 4 | 🧠 Complex reasoning |
+| `claude-sonnet-4-20250514` | Versatile general tasks | ⚖️ Balanced performance |
+| `claude-opus-4-5-20251101` | Claude 4.5 Opus | 🧠 Top-tier reasoning |
+| `claude-sonnet-4-5-20250929` | Claude 4.5 Sonnet | ⚖️ Best overall balance |
+| `claude-3-7-sonnet-20250219` | Stable and reliable | 🛡️ Production use |
 | `claude-3-5-sonnet-20241022` | Efficient, lighter model | 💨 Fast responses |
 
 </details>

--- a/ai_providers.py
+++ b/ai_providers.py
@@ -81,7 +81,7 @@ class AIProviders:
                     "openai": "gpt-4.1",
                     "gemini": "gemini-2.5-flash-lite-preview-06-17",
                     "grok": "grok-4",
-                    "claude": "claude-4-sonnet-20250514",
+                    "claude": "claude-sonnet-4-20250514",
                     "deepseek": "deepseek-chat",
                     "groq_fast": "llama-3.1-70b-versatile",
                     "perplexity": "llama-3.1-sonar-large-128k-online",
@@ -342,7 +342,7 @@ class AIProviders:
     async def get_claude_opinion(
         self,
         prompt: str,
-        model: str = "claude-4-sonnet-20250514",
+        model: str = "claude-sonnet-4-20250514",
         temperature: float = 0.7,
         max_tokens: int = 8000,
         reset_conversation: bool = False,

--- a/mcp_server.py
+++ b/mcp_server.py
@@ -320,8 +320,16 @@ class MCPServer:
                         "model": {
                             "type": "string",
                             "description": "Claude model to use",
-                            "enum": ["claude-4-opus-20250522", "claude-4-sonnet-20250522", "claude-3-7-sonnet-20250224", "claude-3-5-sonnet-20241022"],
-                            "default": "claude-4-sonnet-20250514"
+                            "enum": [
+                                "claude-sonnet-4-20250514",
+                                "claude-sonnet-4-5-20250929",
+                                "claude-opus-4-20250514",
+                                "claude-opus-4-1-20250805",
+                                "claude-opus-4-5-20251101",
+                                "claude-3-7-sonnet-20250219",
+                                "claude-3-5-sonnet-20241022"
+                            ],
+                            "default": "claude-sonnet-4-20250514"
                         },
                         "temperature": {
                             "type": "number",

--- a/model_priority.json
+++ b/model_priority.json
@@ -92,7 +92,7 @@
     },
     {
       "platform": "claude",
-      "model": "claude-4-sonnet-20250514",
+      "model": "claude-sonnet-4-20250514",
       "description": "Anthropic's balanced model - great for general tasks",
       "quality_score": 90
     },
@@ -122,7 +122,7 @@
     },
     {
       "platform": "claude",
-      "model": "claude-4-opus-20250522",
+      "model": "claude-opus-4-20250514",
       "description": "Anthropic's most powerful model - highest capability, but slow and sometimes errors",
       "quality_score": 95
     },
@@ -194,7 +194,7 @@
     },
     {
       "platform": "claude",
-      "model": "claude-3-7-sonnet-20250224",
+      "model": "claude-3-7-sonnet-20250219",
       "description": "Anthropic's stable previous generation",
       "quality_score": 74
     },
@@ -275,23 +275,23 @@
   ],
   "personality_defaults": {
     "honest": {
-      "preferred_models": ["grok-4", "gpt-4.1", "gemini-2.5-flash", "grok-3", "claude-4-sonnet-20250514", "deepseek-chat"],
+      "preferred_models": ["grok-4", "gpt-4.1", "gemini-2.5-flash", "grok-3", "claude-sonnet-4-20250514", "deepseek-chat"],
       "reason": "These models tend to be more direct and factual"
     },
     "friend": {
-      "preferred_models": ["grok-4", "claude-4-sonnet-20250514", "gemini-2.5-flash", "gpt-4.1"],
+      "preferred_models": ["grok-4", "claude-sonnet-4-20250514", "gemini-2.5-flash", "gpt-4.1"],
       "reason": "These models are better at emotional and supportive responses"
     },
     "coach": {
-      "preferred_models": ["grok-4", "gpt-4.1", "gemini-2.5-flash", "claude-4-opus-20250522", "grok-3"],
+      "preferred_models": ["grok-4", "gpt-4.1", "gemini-2.5-flash", "claude-opus-4-20250514", "grok-3"],
       "reason": "These models excel at motivational and goal-oriented responses"
     },
     "wise": {
-      "preferred_models": ["grok-4", "claude-4-opus-20250522", "gemini-2.5-pro", "gemini-2.5-flash", "gpt-4.1"],
+      "preferred_models": ["grok-4", "claude-opus-4-20250514", "gemini-2.5-pro", "gemini-2.5-flash", "gpt-4.1"],
       "reason": "These models provide the most thoughtful and philosophical responses"
     },
     "creative": {
-      "preferred_models": ["grok-4", "gpt-4o", "gpt-4.1", "gemini-2.5-flash", "claude-4-sonnet-20250514"],
+      "preferred_models": ["grok-4", "gpt-4o", "gpt-4.1", "gemini-2.5-flash", "claude-sonnet-4-20250514"],
       "reason": "These models are most innovative and artistic in their responses"
     }
   }


### PR DESCRIPTION
## What
This updates the hard-coded Claude model IDs used by Second Opinion to match the actual model IDs returned by Anthropic’s `GET /v1/models`.

## Why
Several Claude model IDs in the repo were invalid/outdated (e.g., `claude-4-sonnet-...`, `claude-4-opus-...`, and an incorrect `claude-3-7-sonnet-...` date), which causes runtime errors like “model not found”.

## Changes
- Update default Claude model in `ai_providers.py` to `claude-sonnet-4-20250514`
- Update `model_priority.json` references to valid Anthropic Claude IDs
- Update `mcp_server.py` schema enum/default to valid IDs and include Claude 4.5 entries
- Update `README.md` model table accordingly

## Verified
- Confirmed valid model IDs via Anthropic API response (models list):
  - `claude-sonnet-4-20250514`
  - `claude-opus-4-20250514`
  - `claude-sonnet-4-5-20250929`
  - `claude-opus-4-5-20251101`
  - `claude-opus-4-1-20250805`
  - `claude-3-7-sonnet-20250219`
- `python -m py_compile *.py` passes locally

## Notes
This PR intentionally changes only model *names/IDs*, not API versions or other behavior.